### PR TITLE
patch comments into original theme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:10-alpine as build
 RUN apk add git
-RUN wget https://github.com/kotatsuclub/Casper-KotatsuClub/archive/2.11.1-kotatsuclub.zip && unzip 2.11.1-kotatsuclub.zip
 RUN git clone https://github.com/shawntoffel/ghost-imgur-https.git
 RUN cd ghost-imgur-https && npm install
 
 FROM ghost:2.37.0-alpine
-COPY --from=build Casper-KotatsuClub-2.11.1-kotatsuclub content/themes/Casper-KotatsuClub-2.11.1-kotatsuclub
 COPY --from=build ghost-imgur-https content/adapters/storage/ghost-imgur
+COPY theme.patch /tmp/theme.patch
+WORKDIR $GHOST_INSTALL/content.orig/themes/casper
+RUN patch -p1 < /tmp/theme.patch && rm /tmp/theme.patch
+WORKDIR $GHOST_INSTALL
+
 ENV storage__active ghost-imgur

--- a/theme.patch
+++ b/theme.patch
@@ -1,0 +1,29 @@
+diff --git a/post.hbs b/post.hbs
+index f58e0b4..1e78b64 100644
+--- a/post.hbs
++++ b/post.hbs
+@@ -75,11 +75,21 @@ into the {body} of the default.hbs template --}}
+ 
+             </footer>
+ 
+-            {{!--
+             <section class="post-full-comments">
+-                If you want to embed comments, this is a good place to do it!
++                <div id="disqus_thread"></div>
++                <script>
++                    var disqus_config = function () {
++                        this.page.url = '{{url absolute="true"}}';
++                        this.page.identifier = 'ghost-{{comment_id}}';
++                    };
++                    (function() {
++                        var d = document, s = d.createElement('script');
++                        s.src = 'https://kotatsuclub.disqus.com/embed.js';
++                        s.setAttribute('data-timestamp', +new Date());
++                        (d.head || d.body).appendChild(s);
++                    })();
++                </script>
+             </section>
+-            --}}
+ 
+         </article>
+ 


### PR DESCRIPTION
Eliminates the need to maintain a separate theme fork. Ghost will also default to the correctly patched theme automatically since themes are baked into the ghost image. 